### PR TITLE
fix: catch block commands should be wrapped within %{} block

### DIFF
--- a/live-grep.kak
+++ b/live-grep.kak
@@ -11,7 +11,7 @@ define-command -docstring "start a live grep in the *grep* buffer" live-grep %{
         set-option buffer filetype grep
         try %{
           set-option buffer jump_current_line 0
-        } catch {
+        } catch %{
           set-option buffer grep_current_line 0
         }
         set-option window idle_timeout %opt{live_grep_timeout}


### PR DESCRIPTION
I was using kakoune with commit https://github.com/mawww/kakoune/tree/2d9c84e363d499eb699540c53d9f912f446a4d30 with the following error when invoking `live-grep` command:

```
'evaluate-commands': 4:9: 'try': 1:1: '{': no such command
```

Since latest kakoune cannot be built on my macOS machine, I cannot test with latest commit.