### PR TITLE
Prevent ripgrep's stdin detection by redirecting stdin to /dev/null

### DIFF
--- a/live-grep.kak
+++ b/live-grep.kak
@@ -21,7 +21,7 @@ define-command -docstring "start a live grep in the *grep* buffer" live-grep %{
                 if [ -z "$kak_quoted_text" ]; then
                     exit
                 fi
-                result=$($kak_opt_grepcmd "$kak_quoted_text" | tr -d '\r' | head -n $kak_opt_live_grep_results_limit)
+                result=$($kak_opt_grepcmd "$kak_quoted_text" < /dev/null | tr -d '\r' | head -n $kak_opt_live_grep_results_limit)
                 echo "$result"
               }
               execute-keys '<a-;>%<a-;>"_d<a-;>P<a-;>gg'


### PR DESCRIPTION
Hi @raiguard, thanks for this plugin!

I had the problem that with my custom `grepcmd` which uses ripgrep, no results were being shown.
`ripgrep --debug` detects `use_fifo=true` and infers `stdin_readable=true`, and hence tries to read the search context from stdin instead of using files in the current directory, and as such doesn't show any results.
Redirecting stdin to /dev/null prevents that. I suppose ripgrep detects `use_fifo=true` because of something that Kakoune is doing in `%sh{}` contexts, but I'm not sure about the details there. Maybe there's a better fix?

But anyways, this change doesn't interfere with e.g. the default grepcmd `grep -RHn`, because we want to search the files anyways, not stdin.